### PR TITLE
Update readme (thanks, cargo-abcr!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,51 @@
-# restest
-
 Black-box integration test for REST APIs in Rust.
 
-This crate provides the [`assert_api`] macro that allows to declaratively
-test, given a certain request, that the response emitted by the server is
-correct.
+`restest` provides primitives that allow to write REST API in a declarative
+manner. It leverages the Rust test framework and uses macro-assisted pattern
+tho assert for a pattern and add specified variables to scope.
+
+## Adding to the `Cargo.toml`
+
+`restest` provides test-only code. As such, it can be added as a
+dev-dependency:
+
+```TOML
+[dev-dependencies]
+restest = "0.1.0"
+```
 
 ## Example
 
 ```rust
-#![feature(assert_matches)]
+use restest::{assert_body_matches, path, Context, Request};
 
 use serde::{Deserialize, Serialize};
+use http::StatusCode;
 
-restest::port! { 8080 }
+const CONTEXT: Context = Context::new().with_port(8080);
 
-restest::assert_api! {
-    POST "/user",
-    PostUser {
-        year_of_birth: 2000,
-    } => User {
-        year_of_birth: 2000,
+let request = Request::post(path!["user/ghopper"]).with_body(PostUser {
+    year_of_birth: 1943,
+});
+
+let body = CONTEXT
+    .run(request)
+    .await
+    .expect_status(StatusCode::OK)
+    .await;
+
+assert_body_matches! {
+    body,
+    User {
+        year_of_birth: 1943,
         ..
     }
 }
 
-#[derive(Debug, Serialize)]
 struct PostUser {
     year_of_birth: usize,
 }
 
-#[derive(Debug, Deserialize)]
 struct User {
     year_of_birth: usize,
     id: Uuid
@@ -39,53 +54,108 @@ struct User {
 
 ## Writing tests
 
-The [`port`] macro sets the port at which the request must be run.
+Writing tests using `restest` always follow the same patterns. They are
+described below.
 
-The tests are written as normal Rust tests (ie: functions annotated with
-`#[test]`). As we're using asynchronous code, we must write async tests,
-perhaps using `#[tokio::test]`.
+### Specifying the context
 
-More specifically, the [`assert_api`] macro can be used in order to query
-the server API and analyze its response.
+The `Context` object handles all the server-specific configuration:
 
-## Running tests
+* which base URL should be used,
+* which port should be used.
 
-The server must be running in the background when `cargo test` is run.
-
-## Required toolchain
-
-The `nightly` feature allows the [`assert_api`] macro to expand to
-nightly-specific code. This offers the following features:
-
-- better panic message when the request body does not match the expected
-  pattern (requires [`assert_matches`]),
-- ability to reuse variables matched in the response body (requires
-  [`let_else`]) (_still WIP_).
-
-These two features must be added at the crate root using the following two
-lines:
+It can be created with `Context::new`. All its setters are `const`, so
+it can be initialized once for all the tests of a module:
 
 ```rust
-#![feature(assert_matches)]
-#![feature(let_else)]
+use restest::Context;
+
+const CONTEXT: Context = Context::new().with_port(8080);
+
+async fn test_first_route() {
+    // Test code that use `CONTEXT` for a specific route
+}
+
+async fn test_second_route() {
+    // Test code that use `CONTEXT` again for another route
+}
 ```
 
-[`assert_matches`]: https://github.com/rust-lang/rust/issues/82775
-[`let_else`]: https://github.com/rust-lang/rust/issues/87335
+As we're running `async` code under the hood, all the tests must be `async`,
+hence the use of `tokio::test`
 
-## Code of Conduct
+## Creating a request
 
-We have a Code of Conduct so as to create a more enjoyable community and
-work environment. Please see the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
-file for more details.
+Let's focus on the test function itself.
 
-## License
+The first thing to do is to create a `Request` object. This object allows
+to specify characteristics about a specific request that is performed later.
 
-Licensed under either of
+Running `Request::get` allows to construct a GET request to a specific
+URL. Header keys can be specified by calling the `with_header` method. The
+final `Request` is built by calling the `with_body` method, which allows to add
+a body.
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+```rust
+use restest::{path, Request};
 
-at your option.
+let request = Request::get(path!["users", "scrabsha"])
+    .with_header("token", "mom-said-yes")
+    .with_body(());
+```
 
-Dual MIT/Apache2 is strictly more permissive
+Similarly, POST requests can be creating by using \[`Request::post`\] instead
+of \[`Request::get`\].
+
+## Performing the request
+
+Once that the `Request` object has been created, we can run the request by
+passing the `Request` to the `Context` when calling `Context::run`. Once
+`await`-ed, the `expect_status` method checks for the request status code and
+converts the response body to the expected output type.
+
+```rust
+use http::StatusCode;
+use uuid::Uuid;
+use serde::Deserialize;
+
+let user: User = CONTEXT
+    .run(request)
+    .await
+    .expect_status(StatusCode::OK)
+    .await;
+
+struct User {
+    name: String,
+    age: u8,
+    id: Uuid,
+}
+```
+
+## Checking the response body
+
+Properties about the response body can be asserted with `assert_body_matches`.
+The macro supports the full rust pattern syntax, making it easy to check for
+expected values and variants. It also provides bindings, allowing you to bring
+data from the body in scope:
+
+```rust
+use restest::assert_body_matches;
+
+assert_body_matches! {
+    user,
+    User {
+        name: "Grace Hopper",
+        age: 85,
+        id,
+    },
+}
+
+// id is now a variable that can be used:
+println!("Grace Hopper has id `{}`", id);
+```
+
+The extracted variable can be used for next requests or more complex
+testing.
+
+*And that's it!*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# `restest`
+
 Black-box integration test for REST APIs in Rust.
 
 `restest` provides primitives that allow to write REST API in a declarative


### PR DESCRIPTION
Steps to reproduce:
  - kindly ask to @scrabsha the source code of (yet unreleased) `cargo-abcr`,
  - remove every broken link.

There rendered version is available [here](https://github.com/iomentum/restest/blob/scrabsha/update-readme/README.md)