### PR TITLE
feat(expect_status): add more information to the assert_eq for debug

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -273,7 +273,15 @@ impl RequestResult {
     where
         T: DeserializeOwned,
     {
-        assert_eq!(self.response.status(), status);
+        assert_eq!(
+            self.response.status(),
+            status,
+            "Unexpected server response code. Body is {}",
+            self.response
+                .text()
+                .await
+                .expect("Unexpected server response code. Unable to ready body of the response")
+        );
 
         self.response
             .json()


### PR DESCRIPTION
- This adds a lot of debug informations to understand what went wrong during the request, and to help contextualising the request performed.

Maybe not the cleanest since we .expect().
But since we are tryng to .json after it would still be panicking anyway currently, so it should not be dirtier than the current solution (about the opening of the response with either .json() or .text() ).
Even if this could be improved later on.

All input is welcome about this PR!

fixes #20 