### PR TITLE
feat(request): add context description

### DIFF
--- a/examples/user_server_test.rs
+++ b/examples/user_server_test.rs
@@ -174,9 +174,11 @@ pub async fn delete_user() {
 #[tokio::test]
 pub async fn put_user() {
     // Create a new Request object, just as we did for the post_user test.
-    let request = Request::post("users").with_body(UserInput {
-        year_of_birth: 2000,
-    });
+    let request = Request::post("users")
+        .with_body(UserInput {
+            year_of_birth: 2000,
+        })
+        .with_context("Create a user");
 
     // Similarly, execute the said request and get the output.
     let user = CONTEXT

--- a/src/context.rs
+++ b/src/context.rs
@@ -110,6 +110,9 @@ impl Context {
             .await
             .expect("Request failed");
 
-        RequestResult { response }
+        RequestResult {
+            response,
+            context_description: request.context_description.clone(),
+        }
     }
 }


### PR DESCRIPTION
(This builds on the PR #22 to add more informations on the expect status)

Here we had the context of the request to the expect_status panic message, allowing us to know which request failed the test.

Default value will be "Method + url", but it can be overriden with a with_context("Some string") to specify our own context.

![image](https://user-images.githubusercontent.com/13097851/172665163-ec1b852d-5eb3-4581-bde2-8faa3d920eb9.png)

fixes #21 
