### PR TITLE
Proposal: Add additional methods to RequestResult

### DIFF
--- a/examples/user_server.rs
+++ b/examples/user_server.rs
@@ -76,8 +76,8 @@ impl Database {
     fn delete_route(self) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
         method::delete().and(path::param()).map(move |id| {
             match self.users.lock().unwrap().remove(&id) {
-                Some(_) => with_status(json(&"User deleted"), StatusCode::OK),
-                None => with_status(json(&"Failed to delete user"), StatusCode::NOT_FOUND),
+                Some(_) => StatusCode::OK,
+                None => StatusCode::NOT_FOUND,
             }
         })
     }

--- a/examples/user_server_test.rs
+++ b/examples/user_server_test.rs
@@ -180,7 +180,7 @@ pub async fn delete_user() {
     CONTEXT
         .run(&request)
         .await
-        .expect_status_empty_body(StatusCode::OK)
+        .expect_status_empty_body(StatusCode::OK) // Panicking version
         .await;
 
     // We try to delete the same user again and ensure that the server
@@ -188,8 +188,9 @@ pub async fn delete_user() {
     CONTEXT
         .run(request)
         .await
-        .expect_status_empty_body(StatusCode::NOT_FOUND)
-        .await;
+        .ensure_status_empty_body(StatusCode::NOT_FOUND) // Result<_, _> version
+        .await
+        .unwrap();
 }
 
 /// Test for the PUT route.
@@ -232,6 +233,15 @@ pub async fn put_user() {
     assert_body_matches! {
         response,
         User { year_of_birth: 2001, .. },
+    };
+
+    let request = Request::get(path!["users", id]);
+
+    let response = CONTEXT.run(request).await.deserialize_body().await;
+
+    assert_body_matches! {
+        response,
+        Ok(User { year_of_birth: 2001, ..})
     };
 }
 

--- a/examples/user_server_test.rs
+++ b/examples/user_server_test.rs
@@ -180,7 +180,7 @@ pub async fn delete_user() {
     CONTEXT
         .run(&request)
         .await
-        .expect_status::<String>(StatusCode::OK)
+        .expect_status_empty_body(StatusCode::OK)
         .await;
 
     // We try to delete the same user again and ensure that the server
@@ -188,7 +188,7 @@ pub async fn delete_user() {
     CONTEXT
         .run(request)
         .await
-        .expect_status::<String>(StatusCode::NOT_FOUND)
+        .expect_status_empty_body(StatusCode::NOT_FOUND)
         .await;
 }
 

--- a/examples/user_server_test.rs
+++ b/examples/user_server_test.rs
@@ -140,13 +140,20 @@ pub async fn ensure_status_failing() {
     // Similarly, execute the said request and get the output.
     // This time, trying to make the ensure_status fail with a wrong status code
     let response = CONTEXT
-        .run(request)
+        .run(&request)
         .await
-        .ensure_status::<User>(StatusCode::ACCEPTED)
+        .ensure_status_ignore_body(StatusCode::ACCEPTED) // Result<_, _> version
         .await;
 
     // testing if it is returning an error
     assert!(response.is_err());
+
+    // Now we check the correct status code
+    CONTEXT
+        .run(request)
+        .await
+        .expect_status_ignore_body(StatusCode::CREATED) // Panicking version
+        .await;
 }
 
 /// Test for the DELETE route.

--- a/src/request.rs
+++ b/src/request.rs
@@ -436,7 +436,7 @@ impl RequestResult {
     /// This method panics if the server response status is not equal to `status` or if the
     /// body could not be checked to be empty.
     #[track_caller]
-    pub async fn expect_status_empty_body(self, status: StatusCode) -> () {
+    pub async fn expect_status_empty_body(self, status: StatusCode) {
         match self.ensure_status_empty_body(status).await {
             Ok(()) => (),
             Err(err) => panic!("{}", err),

--- a/src/request.rs
+++ b/src/request.rs
@@ -304,13 +304,53 @@ impl RequestResult {
     ///
     /// # Error
     ///
-    /// This method return an error if the server response status is not equal to
+    /// This method returns an error if the server response status is not equal to
     /// `status` or if the body can not be deserialized to the specified type.
     #[track_caller]
     pub async fn ensure_status<T>(self, status: StatusCode) -> Result<T, String>
     where
         T: DeserializeOwned,
     {
+        self.ensure_status_ignore_body(status)
+            .await?
+            .deserialize_body()
+            .await
+    }
+
+    /// Deserializes the body of the response into a concrete type.
+    ///
+    /// This method uses `serde` internally, so the output type must implement
+    /// [`DeserializeOwned`].
+    ///
+    /// # Error
+    ///
+    /// This method returns an error if the body can not be deserialized to the
+    /// specified type.
+    #[track_caller]
+    pub async fn deserialize_body<T>(self) -> Result<T, String>
+    where
+        T: DeserializeOwned,
+    {
+        self.response.json().await.map_err(|err| {
+            format!(
+                "Failed to deserialize body for request '{}': {}",
+                self.context_description, err
+            )
+        })
+    }
+
+    /// Checks if the response status meets an expected status code. No check is
+    /// performed on the body.
+    ///
+    /// # Error
+    ///
+    /// This method returns an error if the server response status is not equal to
+    /// `status`.
+    #[track_caller]
+    pub async fn ensure_status_ignore_body(
+        self,
+        status: StatusCode,
+    ) -> Result<RequestResult, String> {
         if self.response.status() != status {
             return Err(format!("Unexpected server response code for request '{}'. Body is {}",
             self.context_description,
@@ -321,11 +361,85 @@ impl RequestResult {
             )?));
         }
 
-        self.response.json().await.map_err(|err| {
-            format!(
-                "Failed to deserialize body for request '{}': {}",
-                self.context_description, err
-            )
-        })
+        Ok(self)
+    }
+
+    /// Checks if the response status meets an expected status code. No check is
+    /// performed on the body.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the server response status is not equal to `status`.
+    #[track_caller]
+    pub async fn expect_status_ignore_body(self, status: StatusCode) {
+        match self.ensure_status_ignore_body(status).await {
+            Ok(_) => {}
+            Err(err) => panic!("{}", err),
+        }
+    }
+
+    /// Checks if the response body is empty.
+    ///
+    /// The `Content-length` header is first checked; if it is missing (e.g. in case of
+    /// a compressed payload or a chunked transfer encoding), the body is fetched and its
+    /// length is checked.
+    ///
+    /// # Error
+    ///
+    /// This method returns an error if the body could not be checked to be empty.
+    #[track_caller]
+    pub async fn ensure_empty_body(self) -> Result<(), String> {
+        if matches!(self.response.content_length(), Some(0))
+            || self
+                .response
+                .text()
+                .await
+                .map_err(|err| {
+                    format!(
+                        "Failed to check body for request '{}': {}",
+                        self.context_description, err
+                    )
+                })?
+                .is_empty()
+        {
+            Ok(())
+        } else {
+            Err(format!(
+                "Unexpected body for request '{}'",
+                self.context_description
+            ))
+        }
+    }
+
+    /// Checks if the response body meets an expected status code and the body is empty.
+    ///
+    /// See `ensure_empty_body` for more details.
+    ///
+    /// # Error
+    ///
+    /// This method returns an error if the server response status is not equal to
+    /// `status` or if the body could not be checked to be empty.
+    #[track_caller]
+    pub async fn ensure_status_empty_body(self, status: StatusCode) -> Result<(), String> {
+        self.ensure_status_ignore_body(status)
+            .await?
+            .ensure_empty_body()
+            .await
+    }
+
+    /// Checks if the response body meets an expected status code and the body is empty.
+    ///
+    /// See `ensure_empty_body` for more details.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the server response status is not equal to `status` or if the
+    /// body could not be checked to be empty.
+    #[track_caller]
+    pub async fn expect_status_empty_body(self, status: StatusCode) -> () {
+        match self.ensure_status_empty_body(status).await {
+            Ok(()) => (),
+            Err(err) => panic!("{}", err),
+        }
     }
 }


### PR DESCRIPTION
This PR adds the following methods to `RequestResult`:
- `deserialize_body`: Deserializes the body without performing checks on status code or content.
- `ensure_status_ignore_body`: Checks the status code while ignoring body.
- `expect_status_ignore_body`: Checks the status code while ignoring body, panic on failure.
- `ensure_empty_body`: Checks that the body is empty.
- `ensure_status_empty_body`: Checks the status code and the emptiness of the body.
- `expect_status_empty_body`: Checks the status code and the emptiness of the body, panic on failure.

<hr>

The last two items, specifically, are an attempt to fix #25 while both
- keeping the public-facing API unchanged for the sole existing use case (check status code & body)
- providing both try (`ensure_* -> Result`) and panic (`expect_* -> Either<(), !>`) versions of the corresponding methods
<hr>

Any criticism on the API structure in itself would be much appreciated.
- is preservation of the public API surface important enough at this point in the project to justify opting for `ensure_thing1_thing2` rather than a builder pattern (`.ensure_thing1().ensure_thing2()`)? The latter, if chosen, would require breaking the current API since `expect_status` should then only check for status, not body as currently is the case.