### PR TITLE
feat(ensure_status): display request body in most error cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ http = "0.2"
 reqwest = { version = "0.11", features = ["json"] }
 restest_macros = "0.1.0"
 serde = "1.0"
+serde_json = "1.0"
 anyhow = "1.0.58"
 
 [dev-dependencies]


### PR DESCRIPTION
Tried to use a simpler 4 way path (either body is incorrect, or can't be deserialized, or status is unexpected or Happy path.

This allows to get the body first hand and to have it consistently to describe what we are receiving to the debugging user that is using restest for his tests.